### PR TITLE
Fix registro update API

### DIFF
--- a/frontend/src/FuncionarioDetalhes.jsx
+++ b/frontend/src/FuncionarioDetalhes.jsx
@@ -35,10 +35,11 @@ export default function FuncionarioDetalhes() {
     }, [id]);
 
     const handleEditar = async (registroId, tipo, data_hora) => {
+        const isoDataHora = new Date(data_hora).toISOString();
         const res = await fetch(`http://localhost:8080/registros/${registroId}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ tipo, data_hora })
+            body: JSON.stringify({ usuario_id: id, tipo, data_hora: isoDataHora })
         });
         if (res.ok) {
             setMensagem('Registro atualizado.');
@@ -81,7 +82,11 @@ export default function FuncionarioDetalhes() {
                     const res = await fetch('http://localhost:8080/registros/manual', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ usuario_id: id, tipo: novoTipo, data_hora: novaDataHora })
+                        body: JSON.stringify({
+                            usuario_id: id,
+                            tipo: novoTipo,
+                            data_hora: new Date(novaDataHora).toISOString()
+                        })
                     });
 
                     if (res.ok) {

--- a/registro-service/pom.xml
+++ b/registro-service/pom.xml
@@ -68,6 +68,10 @@
                         <groupId>org.aspectj</groupId>
                         <artifactId>aspectjweaver</artifactId>
                 </dependency>
+                <dependency>
+                        <groupId>org.apache.httpcomponents.client5</groupId>
+                        <artifactId>httpclient5</artifactId>
+                </dependency>
         </dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/registro-service/src/main/java/com/pontofacil/registroservice/service/SupabaseService.java
+++ b/registro-service/src/main/java/com/pontofacil/registroservice/service/SupabaseService.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -25,7 +28,12 @@ public class SupabaseService {
     @Value("${supabase.serviceKey}")
     private String supabaseKey;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
+
+    public SupabaseService() {
+        CloseableHttpClient client = HttpClients.createDefault();
+        this.restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory(client));
+    }
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private HttpHeaders headers() {


### PR DESCRIPTION
## Summary
- support HTTP PATCH in registro-service RestTemplate
- add httpclient5 to registro-service dependencies

## Testing
- `npm run lint` *(fails: Missing script 'lint')*
- `registro-service/mvnw -q test -f registro-service/pom.xml` *(fails: Permission denied)*
- `usuario-service/mvnw -q test -f usuario-service/pom.xml` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68424ad2898c832a947868b3cc13ba0c